### PR TITLE
Fixing no internet connection

### DIFF
--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -327,7 +327,7 @@ if [ "$1" != restart ]; then
   done
 
   old_internet_device=$(ynh_setting_get hotspot internet_device)
-  new_internet_device=$(ip route | awk '/default via/ { print $NF; }')
+  new_internet_device=$(ip --json route | jq -r '.[] | select(.dst == "default") | .dev')
 
   # Switch the NAT interface if there is a VPN
   ip link show dev tun0 &> /dev/null

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -327,7 +327,7 @@ if [ "$1" != restart ]; then
   done
 
   old_internet_device=$(ynh_setting_get hotspot internet_device)
-  new_internet_device=$(ip --json route | jq -r '.[] | select(.dst == "default") | .dev')
+  new_internet_device=$(ip route get 1.2.3.4 | awk '{ print $5; }')
 
   # Switch the NAT interface if there is a VPN
   ip link show dev tun0 &> /dev/null


### PR DESCRIPTION
## Problem

Before this PR, (and after having run `ynh-hotspot`), `iptables -nvL -t nat` outputs:
```
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 MASQUERADE  all  --  *      202     0.0.0.0/0            0.0.0.0/0
```
(note the weird `out:202`)

After this PR, `iptables -nvL -t nat` correctly outputs:
```
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    2   181 MASQUERADE  all  --  *      eth0    0.0.0.0/0            0.0.0.0/0
```

## Solution

I don't know for others but on my setup (see https://github.com/YunoHost-Apps/hotspot_ynh/issues/87) `ip routes` outputs:
```
ip route
default via 192.168.1.1 dev eth0 proto dhcp src 192.168.1.20 metric 202
```
then the original line
```
new_internet_device=$(ip route | awk '/default via/ { print $NF; }')
```
was outputting `202` instead of `eth0`.


## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [ x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
