### PR TITLE
Fix DHCP cleanup

### DIFF
--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -158,7 +158,7 @@ start_dhcpd() {
         sed "s|__IP4_DNS__|${ip4_dns[${i}]}|g" -i /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf
         sed "s|__IP4_NAT_PREFIX__|${ip4_nat_prefix[${i}]}|g" -i /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf
 
-        dnsmasq -C /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf -p0
+        dnsmasq -C /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf -p0 -x /run/dnsmasq/dnsmasq-dhcpv4-ssid${i}.pid
     fi
 
     # Run DHCPv6 server
@@ -171,7 +171,7 @@ start_dhcpd() {
         sed "s|__IP6_DNS__|${ip6_dns[${i}]}|g" -i /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf
         sed "s|__IP6_NET__|${ip6_net[${i}]}|g" -i /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf
 
-        dnsmasq -C /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf -p0
+        dnsmasq -C /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf -p0 -x /run/dnsmasq/dnsmasq-dhcpv6-ssid${i}.pid
     fi
 }
 
@@ -249,13 +249,13 @@ stop_dhcpd() {
     if is_dhcpd6_running ${i}; then
         echo "hotspot${i}: Stop the NDP and DHCPv6 server (dnsmasq)"
         kill $(ps aux | grep 'dhcpdv6-ssid' | grep -v grep | awk '{ print $2 }')
-        rm -f /etc/dnsmasq.d/dhcpdv6-ssid*.conf
+        rm -f /etc/dnsmasq.dhcpd/dhcpdv6-ssid*.conf
     fi
 
     if is_dhcpd4_running ${i}; then
         echo "hotspot${i}: Stop the DHCPv4 server (dnsmasq)"
         kill $(ps aux | grep 'dhcpdv4-ssid' | grep -v grep | awk '{ print $2 }')
-        rm -f /etc/dnsmasq.d/dhcpdv4-ssid*.conf
+        rm -f /etc/dnsmasq.dhcpd/dhcpdv4-ssid*.conf
     fi
 }
 

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -73,13 +73,13 @@ is_forwarding_set() {
 is_dhcpd6_running() {
     local i=${1}
 
-    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid" ]]
+    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid" ]] && ps -p $(cat "/run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid") > /dev/null
 }
 
 is_dhcpd4_running() {
     local i=${1}
 
-    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid" ]]
+    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid" ]] && ps -p $(cat "/run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid") > /dev/null
 }
 
 is_hostapd_running() {
@@ -249,12 +249,14 @@ stop_dhcpd() {
     if is_dhcpd6_running ${i}; then
         echo "hotspot${i}: Stop the NDP and DHCPv6 server (dnsmasq)"
         kill $(cat /run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid)
+        rm -f /run/dnsmasq/dnsmasq-dhcpdv6-ssid${1}.pid
         rm -f /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf
     fi
 
     if is_dhcpd4_running ${i}; then
         echo "hotspot${i}: Stop the DHCPv4 server (dnsmasq)"
         kill $(cat /run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid)
+        rm -f /run/dnsmasq/dnsmasq-dhcpdv4-ssid${1}.pid
         rm -f /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf
     fi
 }

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -73,13 +73,13 @@ is_forwarding_set() {
 is_dhcpd6_running() {
     local i=${1}
 
-    ps aux | grep "dhcpdv6-ssid${i}" | grep -qv grep
+    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid" ]]
 }
 
 is_dhcpd4_running() {
     local i=${1}
 
-    ps aux | grep "dhcpdv4-ssid${i}" | grep -qv grep
+    [[ -e "/run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid" ]]
 }
 
 is_hostapd_running() {
@@ -248,14 +248,14 @@ stop_dhcpd() {
 
     if is_dhcpd6_running ${i}; then
         echo "hotspot${i}: Stop the NDP and DHCPv6 server (dnsmasq)"
-        kill $(ps aux | grep 'dhcpdv6-ssid' | grep -v grep | awk '{ print $2 }')
-        rm -f /etc/dnsmasq.dhcpd/dhcpdv6-ssid*.conf
+        kill $(cat /run/dnsmasq/dnsmasq-dhcpdv6-ssid${i}.pid)
+        rm -f /etc/dnsmasq.dhcpd/dhcpdv6-ssid${i}.conf
     fi
 
     if is_dhcpd4_running ${i}; then
         echo "hotspot${i}: Stop the DHCPv4 server (dnsmasq)"
-        kill $(ps aux | grep 'dhcpdv4-ssid' | grep -v grep | awk '{ print $2 }')
-        rm -f /etc/dnsmasq.dhcpd/dhcpdv4-ssid*.conf
+        kill $(cat /run/dnsmasq/dnsmasq-dhcpdv4-ssid${i}.pid)
+        rm -f /etc/dnsmasq.dhcpd/dhcpdv4-ssid${i}.conf
     fi
 }
 


### PR DESCRIPTION
## Problem

Some files for the DHCP config are still there when the hotspot is stopped.

## Solution

The cleanup function was removing files in the wrong folder.

I also added a custom pid file for the DHCP servers, not sure if this is needed but it feels cleaner that way.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
