### PR TITLE
Remove/rework openvpn coupling

### DIFF
--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl restart ynh-hotspot

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -20,10 +20,6 @@
 # Functions
 ## State functions
 
-has_vpnclient_app() {
-    [ -e /tmp/.ynh-vpnclient-started ]
-}
-
 has_ip6delegatedprefix() {
     local i=${1}
 
@@ -353,12 +349,6 @@ if [ "$1" != restart ]; then
     old_gateway_interface=$(ynh_setting_get hotspot gateway_interface)
     new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
 
-    # Switch the NAT interface if there is a VPN
-    ip link show dev tun0 &>/dev/null
-    if [ "$?" -eq 0 ]; then
-        new_gateway_interface=tun0
-    fi
-
     echo "OK"
 fi
 
@@ -458,11 +448,6 @@ stop)
     if is_hostapd_running; then
         echo "Stop hostapd"
         stop_hostapd
-    fi
-
-    # Fix configuration
-    if has_vpnclient_app; then
-        ynh-vpnclient start
     fi
     ;;
 restart)

--- a/scripts/backup
+++ b/scripts/backup
@@ -50,6 +50,9 @@ ynh_backup --src_path="/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
 
 ynh_backup --src_path="/usr/local/bin/$service_name"
 
+ynh_backup --src_path="/etc/openvpn/scripts/route-up.d/90-hotspot"
+ynh_backup --src_path="/etc/openvpn/scripts/route-down.d/90-hotspot"
+
 ynh_backup --src_path="/etc/init.d/hostapd"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -117,18 +117,6 @@ ynh_system_user_create --username=$app
 #=================================================
 ynh_script_progression --message="Configuring hotspot..."
 
-if [[ ! -v ip6_net ]]; then # if ip6_net not set
-	ip6_net=""
-
-	if [[ -e /tmp/.ynh-vpnclient-started ]]; then
-		vpnclient_ip6_net=$(ynh_app_setting_get vpnclient ip6_net 2>&1)
-
-		if [[ $vpnclient_ip6_net =~ :: ]]; then
-			ip6_net=${vpnclient_ip6_net}
-		fi
-	fi
-fi
-
 hot_reload_usb_wifi_cards
 wifi_device=$(iw_devices | awk -F\| '{ print $1 }')
 

--- a/scripts/install
+++ b/scripts/install
@@ -165,6 +165,14 @@ install -b -o root -g root -m 0644 ../conf/dnsmasq_dhcpdv4.conf.tpl /etc/dnsmasq
 # Copy init script
 install -o root -g root -m 0755 ../conf/$service_name /usr/local/bin/
 
+# Copy openvpn scripts
+mkdir -pm 0755 /etc/openvpn/scripts
+mkdir -pm 0755 /etc/openvpn/scripts/route-up.d
+mkdir -pm 0755 /etc/openvpn/scripts/route-down.d
+install -o root -g root -m 0755 ../conf/openvpn_90-hotspot /etc/openvpn/scripts/route-up.d/90-hotspot
+install -o root -g root -m 0755 ../conf/openvpn_90-hotspot /etc/openvpn/scripts/route-down.d/90-hotspot
+
+
 #=================================================
 # CONFIGURE HOSTAPD
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -54,6 +54,9 @@ ynh_remove_app_dependencies
 #=================================================
 ynh_script_progression --message="Removing app main directory..."
 
+ynh_secure_remove --file="/etc/openvpn/scripts/route-up.d/90-hotspot"
+ynh_secure_remove --file="/etc/openvpn/scripts/route-down.d/90-hotspot"
+
 # Remove the app directory securely
 ynh_secure_remove --file="/usr/local/bin/$service_name"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -70,6 +70,9 @@ ynh_restore_file --origin_path="/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
 
 ynh_restore_file --origin_path="/usr/local/bin/$service_name"
 
+ynh_restore_file --origin_path="/etc/openvpn/scripts/route-up.d/90-hotspot"
+ynh_restore_file --origin_path="/etc/openvpn/scripts/route-down.d/90-hotspot"
+
 ynh_restore_file --origin_path="/etc/init.d/hostapd"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -141,6 +141,13 @@ install -b -o root -g root -m 0644 ../conf/dnsmasq_dhcpdv4.conf.tpl /etc/dnsmasq
 # Copy init script
 install -o root -g root -m 0755 ../conf/$service_name /usr/local/bin/
 
+# Copy openvpn scripts
+mkdir -pm 0755 /etc/openvpn/scripts
+mkdir -pm 0755 /etc/openvpn/scripts/route-up.d
+mkdir -pm 0755 /etc/openvpn/scripts/route-down.d
+install -o root -g root -m 0755 ../conf/openvpn_90-hotspot /etc/openvpn/scripts/route-up.d/90-hotspot
+install -o root -g root -m 0755 ../conf/openvpn_90-hotspot /etc/openvpn/scripts/route-down.d/90-hotspot
+
 #=================================================
 # SETUP SYSTEMD
 #=================================================


### PR DESCRIPTION
## Problem

The hotspot app is tightly coupled with the vpnclient, which creates side effects difficult to debug.

## Solution

I'm using the openvpn hooks to trigger a restart of the hotspot service whenever the VPN connects / disconnects.

There is room for optimization, but they would require more refactoring.

I'm not really happy with the need to create /etc/openvpn/scripts folders and subfolders, but this is needed if the hotspot app is installed before the openvpn app...

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
