### PR TITLE
Fix DNS config + cleanup stuff when hotspot is disabled

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -103,7 +103,6 @@ name = "Configuration"
         [main.hotspot.dns]
         ask = "DNS resolvers"
         type = "tags"
-        bind = "null"
         visible = "advanced"
         pattern.regexp = '^([0-9.]{7,15}|[0-9a-fA-F:]+)$'
         pattern.error = "Not an ip"

--- a/scripts/config
+++ b/scripts/config
@@ -136,21 +136,24 @@ validate__ip4_nat_prefix() {
 }
 
 validate__dns() {
-    if ! echo "${dns}" | grep -q "\."
+    if [[ -z "$ip4_dns" ]]
     then
         echo 'IPv4 DNS required'
     fi
-    if [[ -n "${ip6_net}" ]] && ! echo "${dns}" | grep -q ":"
+    if [[ -n "${ip6_net}" ]] && [[ -z "$ip6_dns" ]]
     then
         echo 'IPv6 DNS required'
     fi
 }
 
-#=================================================
-# SPECIFIC SETTERS FOR TOML SHORT KEYS
-#=================================================
+ynh_app_config_validate() {
+    if [[ "${advanced}" -eq 0 ]]; then
+        # When we aren't in advanced mode, these variables must be manually declared
+        dns="${old[dns]}"
+        ip6_net="${old[ip6_net]}"
+        ip4_nat_prefix="${old[ip4_nat_prefix]}"
+    fi
 
-set__dns() {
     ip6_dns=""
     ip4_dns=""
     for ip in $(echo "${dns}" | tr ',' ' '); do
@@ -171,7 +174,15 @@ set__dns() {
     if [[ -n "${ip4_nat_prefix}" ]] && [[ -z "${ip4_dns}" ]]; then
         ip4_dns="${ip4_nat_prefix}.1"
     fi
-    
+
+    _ynh_app_config_validate
+}
+
+#=================================================
+# SPECIFIC SETTERS FOR TOML SHORT KEYS
+#=================================================
+
+set__dns() {
     ynh_app_setting_set $app ip6_dns "${ip6_dns}"
     ynh_app_setting_set $app ip4_dns "${ip4_dns}"
 }
@@ -192,14 +203,23 @@ ynh_app_config_apply() {
 
     _ynh_app_config_apply
 
-    configure_hostapd
-    configure_dnsmasq
-    configure_dhcp
+    if [[ "${service_enabled}" -eq 1 ]]; then
+        configure_hostapd
+        configure_dnsmasq
+        configure_dhcp
 
-    # Start hotspot
-    ynh_print_info --message="Starting hotspot service if needed"
-    /usr/local/bin/${service_name} start
+        # Start hotspot
+        ynh_print_info --message="Starting hotspot service if needed"
+        /usr/local/bin/${service_name} start
+    else
+        ynh_print_info --message="Cleanup hotspot config files"
+        ynh_secure_remove --file="/etc/hostapd/$app/hostapd.conf"
+        ynh_secure_remove --file="/etc/dnsmasq.d/$app.conf"
+        ynh_secure_remove --file="/etc/dnsmasq.$app/dhcpdv4.conf"
+        ynh_secure_remove --file="/etc/dnsmasq.$app/dhcpdv6.conf"
 
+        systemctl restart dnsmasq
+    fi
 }
 
 ynh_app_config_run $1


### PR DESCRIPTION
## Problem

When advanced mode is disabled, the following variables are not declared:
- dns
- ip6_net
- ip4_nat_address

These variables are needed to check if IPv4 and IPv6 DNS are valid and to set them.
When the hotspot is enabled, they are also used to configure the service.

## Solution

I moved the code that is splitting IPv4 and IPv6 DNS, in order to reuse them in the DNS validation step.

I make sure that when the advanced mode is disabled, I take variables from the "old" config.
I guess these are the settings before any user changes, which in this case isn't a problem because the fields are hidden from the user.

I also added a check to ensure the hotspot isn't started when it is disabled. Instead, we cleanup some config files, and we restart dnsmasq to make sure changes are updated.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
