### PR TITLE
Reload only NAT rule when OpenVPN is up / down

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 * Combine with the [VPN Client app](https://github.com/labriqueinternet/vpnclient_ynh) to obtain a VPN-protected WiFi
 
 
-**Shipped version:** 2.2.0~ynh1
+**Shipped version:** 2.2.1~ynh1
 
 ## Screenshots
 
@@ -29,6 +29,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 ## Documentation and resources
 
 * Official app website: <https://internetcu.be/>
+* YunoHost Store: <https://apps.yunohost.org/app/hotspot>
 * Report a bug: <https://github.com/YunoHost-Apps/hotspot_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 * À combiner avec l'[app VPN Client](https://github.com/labriqueinternet/vpnclient_ynh) pour obtenir un accès internet aumatiquement protégé par votre VPN
 
 
-**Version incluse :** 2.2.0~ynh1
+**Version incluse :** 2.2.1~ynh1
 
 ## Captures d’écran
 
@@ -29,6 +29,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 ## Documentations et ressources
 
 * Site officiel de l’app : <https://internetcu.be/>
+* YunoHost Store: <https://apps.yunohost.org/app/hotspot>
 * Signaler un bug : <https://github.com/YunoHost-Apps/hotspot_ynh/issues>
 
 ## Informations pour les développeurs

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/share/yunohost/helpers
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 is_nat_set() {
   local gateway_interface=${1}
@@ -17,8 +17,8 @@ set_nat() {
   iptables -w -t nat -A POSTROUTING -o "${gateway_interface}" -j MASQUERADE
 }
 
-if systemctl is-active __SERVICE_NAME__; then
-  old_gateway_interface=$(ynh_app_setting_get --app=__APP__ --key=gateway_interface)
+if systemctl -q is-active __SERVICE_NAME__; then
+  old_gateway_interface=$(yunohost app setting __APP__ gateway_interface)
   new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
 
   if [[ -n "$old_gateway_interface" ]] && [[ "$old_gateway_interface" != "$new_gateway_interface" ]] && is_nat_set "$old_gateway_interface"; then
@@ -29,5 +29,5 @@ if systemctl is-active __SERVICE_NAME__; then
     set_nat "${new_gateway_interface}"
   fi
 
-  ynh_app_setting_set --app=__APP__ --key=gateway_interface --value="${new_gateway_interface}"
+  yunohost app setting __APP__ gateway_interface --value "${new_gateway_interface}"
 fi

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -1,3 +1,29 @@
 #!/bin/bash
 
-systemctl restart __SERVICE_NAME__
+source /usr/share/yunohost/helpers
+
+is_nat_set() {
+  local gateway_interface=${1}
+  iptables -w -nvt nat -L POSTROUTING | grep MASQUERADE | grep -q "${gateway_interface}"
+}
+
+unset_nat() {
+  local gateway_interface=${1}
+  iptables -w -t nat -D POSTROUTING -o "${gateway_interface}" -j MASQUERADE
+}
+
+set_nat() {
+  local gateway_interface=${1}
+  iptables -w -t nat -A POSTROUTING -o "${gateway_interface}" -j MASQUERADE
+}
+
+old_gateway_interface=$(ynh_app_setting_get --app=$app --key=gateway_interface)
+new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
+
+if [[ -n "$old_gateway_interface" ]] && [[ "$old_gateway_interface" != "$new_gateway_interface" ]] && is_nat_set "$old_gateway_interface"; then
+  unset_nat "${old_gateway_interface}"
+fi
+
+set_nat "${new_gateway_interface}"
+
+ynh_app_setting_set --app=$app --key=gateway_interface --value="${new_gateway_interface}"

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -18,7 +18,7 @@ set_nat() {
 }
 
 if systemctl is-active __SERVICE_NAME__; then
-  old_gateway_interface=$(yunohost app setting --app=__APP__ --key=gateway_interface)
+  old_gateway_interface=$(ynh_app_setting_get --app=__APP__ --key=gateway_interface)
   new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
 
   if [[ -n "$old_gateway_interface" ]] && [[ "$old_gateway_interface" != "$new_gateway_interface" ]] && is_nat_set "$old_gateway_interface"; then

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -25,7 +25,9 @@ if systemctl is-active __SERVICE_NAME__; then
     unset_nat "${old_gateway_interface}"
   fi
 
-  set_nat "${new_gateway_interface}"
+  if [[ -n "$new_gateway_interface" ]] && ! is_nat_set $new_gateway_interface; then
+    set_nat "${new_gateway_interface}"
+  fi
 
   ynh_app_setting_set --app=__APP__ --key=gateway_interface --value="${new_gateway_interface}"
 fi

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-
 is_nat_set() {
   local gateway_interface=${1}
   iptables -w -nvt nat -L POSTROUTING | grep MASQUERADE | grep -q "${gateway_interface}"

--- a/conf/openvpn_90-hotspot
+++ b/conf/openvpn_90-hotspot
@@ -17,13 +17,15 @@ set_nat() {
   iptables -w -t nat -A POSTROUTING -o "${gateway_interface}" -j MASQUERADE
 }
 
-old_gateway_interface=$(ynh_app_setting_get --app=$app --key=gateway_interface)
-new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
+if systemctl is-active __SERVICE_NAME__; then
+  old_gateway_interface=$(yunohost app setting --app=__APP__ --key=gateway_interface)
+  new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
 
-if [[ -n "$old_gateway_interface" ]] && [[ "$old_gateway_interface" != "$new_gateway_interface" ]] && is_nat_set "$old_gateway_interface"; then
-  unset_nat "${old_gateway_interface}"
+  if [[ -n "$old_gateway_interface" ]] && [[ "$old_gateway_interface" != "$new_gateway_interface" ]] && is_nat_set "$old_gateway_interface"; then
+    unset_nat "${old_gateway_interface}"
+  fi
+
+  set_nat "${new_gateway_interface}"
+
+  ynh_app_setting_set --app=__APP__ --key=gateway_interface --value="${new_gateway_interface}"
 fi
-
-set_nat "${new_gateway_interface}"
-
-ynh_app_setting_set --app=$app --key=gateway_interface --value="${new_gateway_interface}"

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -258,7 +258,7 @@ start)
         exit 1
     fi
 
-    echo "[hotspot] Starting..."
+    echo "[$app] Starting..."
     touch /tmp/.${service_name}-started
 
     # Check old state of the ipv4 NAT settings
@@ -295,13 +295,13 @@ start)
     start_dhcpd
 
     # Update dynamic settings
-    ynh_app_setting_set hotspot gateway_interface "${new_gateway_interface}"
+    ynh_app_setting_set --app=$app --key=gateway_interface --value="${new_gateway_interface}"
 
     # Regen-conf dnsmasq to enable dns resolution on dnsmasq for the new interface
     yunohost tools regen-conf dnsmasq
     ;;
 stop)
-    echo "[hotspot] Stopping..."
+    echo "[$app] Stopping..."
     rm -f /tmp/.${service_name}-started
 
     if ! is_other_hostapd_running; then


### PR DESCRIPTION
## Problem

For simplicity sake, the OpenVPN is restarting the hotspot each time it goes up or down.
The issue is that it takes really long on ARM boards, such as Olimex.

## Solution

The idea is to reload only network stuff which have changed after the OpenVPN went up or down.
Unless I missed something, we only need to reload the NAT rule…

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
