### PR TITLE
Fix issue of gateway interface detection in the case of VPN usage

### DIFF
--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -237,6 +237,7 @@ if [ "$1" != restart ]; then
 
     old_gateway_interface=$(ynh_app_setting_get --app=$app --key=gateway_interface)
     new_gateway_interface=$(ip route get 1.2.3.4 | awk '$2 ~ /^dev$/ { print $3; } $4 ~ /^dev$/ { print $5; }')
+
     echo "OK"
 fi
 

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -236,6 +236,10 @@ if [ "$1" != restart ]; then
     ip4_nat_prefix=$(ynh_app_setting_get --app=$app --key=ip4_nat_prefix)
 
     old_gateway_interface=$(ynh_app_setting_get --app=$app --key=gateway_interface)
+
+    # The awk syntax is to accomodate to the fact that the ip route output may look like:
+    # 1.2.3.4 via 192.168.1.254 dev end0 src 192.168.1.35 uid 0
+    # 1.2.3.4 dev vpn_iloth table 51820 src 5.6.7.8 uid 0
     new_gateway_interface=$(ip route get 1.2.3.4 | awk '$2 ~ /^dev$/ { print $3; } $4 ~ /^dev$/ { print $5; }')
 
     echo "OK"

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -236,8 +236,7 @@ if [ "$1" != restart ]; then
     ip4_nat_prefix=$(ynh_app_setting_get --app=$app --key=ip4_nat_prefix)
 
     old_gateway_interface=$(ynh_app_setting_get --app=$app --key=gateway_interface)
-    new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')
-
+    new_gateway_interface=$(ip route get 1.2.3.4 | awk '$2 ~ /^dev$/ { print $3; } $4 ~ /^dev$/ { print $5; }')
     echo "OK"
 fi
 


### PR DESCRIPTION
## Problem

The gateway interface is detected with the following code : 
`new_gateway_interface=$(ip route get 1.2.3.4 | awk '{ print $5; }')`
This code works as expected in some cases because `ip route get 1.2.3.4` returns a line where the interface name is in the 5th field, like in this first example : 
```
root@clic:~
# -> ip route get 1.2.3.4 
1.2.3.4 via 192.168.1.254 dev end0 src 192.168.1.35 uid 0 
```
But in some other cases, for example when a wireguard VPN is used to make the server reachable from the internet, the network interface name is in the 3rd field, like in this second example : 
```
root@lab12:~# ip route get 1.2.3.4
1.2.3.4 dev vpn_iloth table 51820 src 5.6.7.8 uid 0 
```
(note that in the above example the actual public IP address of the VPN was replaced by `5.6.7.8` to anonymize it)

## Solution

replace the gateway interface detection code with the following : 
`new_gateway_interface=$(ip route get 1.2.3.4 | awk '$2 ~ /^dev$/ { print $3; } $4 ~ /^dev$/ { print $5; }')`
I have tested that this is working in both cases described above. But I'm no awk expert. There might be a better way to do this that would find the interface name in any other position in the result of `ip route get 1.2.3.4`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
